### PR TITLE
Compatibiity with Vite 8 and rolldown

### DIFF
--- a/src/renderer/details/example-details-v1alpha1.tsx
+++ b/src/renderer/details/example-details-v1alpha1.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { ExamplePreferencesStore } from "../../common/store";
 import { withErrorPage } from "../components/error-page";
 
 import type { Example } from "../k8s/example/example-v1alpha1";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, MarkdownViewer },

--- a/src/renderer/details/example-details-v1alpha2.tsx
+++ b/src/renderer/details/example-details-v1alpha2.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { ExamplePreferencesStore } from "../../common/store";
 import { withErrorPage } from "../components/error-page";
 
 import type { Example } from "../k8s/example/example-v1alpha2";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, MarkdownViewer },

--- a/src/renderer/pages/examples-page-v1alpha1.tsx
+++ b/src/renderer/pages/examples-page-v1alpha1.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../components/error-page";
 import { Example, type ExampleApi } from "../k8s/example/example-v1alpha1";
 import styles from "./examples-page.module.scss";
 import stylesInline from "./examples-page.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, KubeObjectAge, KubeObjectListLayout, LinkToNamespace, WithTooltip },

--- a/src/renderer/pages/examples-page-v1alpha2.tsx
+++ b/src/renderer/pages/examples-page-v1alpha2.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../components/error-page";
 import { Example, type ExampleApi } from "../k8s/example/example-v1alpha2";
 import styles from "./examples-page.module.scss";
 import stylesInline from "./examples-page.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, KubeObjectAge, KubeObjectListLayout, LinkToNamespace, WithTooltip },

--- a/src/renderer/preferences/example-preference.tsx
+++ b/src/renderer/preferences/example-preference.tsx
@@ -1,6 +1,8 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { ExamplePreferencesStore } from "../../common/store";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Checkbox },


### PR DESCRIPTION
Prevents

```
✗ Build failed in 409ms
error during build:
Build failed with 5 errors:

[MISSING_EXPORT] Error: "observer" is not exported by "node_modules/.vite_external/mobx-react.js".
   ╭─[ src/renderer/details/example-details-v1alpha1.tsx:2:10 ]
   │
 2 │ import { observer } from "mobx-react";
   │          ────┬───  
   │              ╰───── Missing export
───╯
```